### PR TITLE
update link to nature cell biology paper to published

### DIFF
--- a/src/assets/content/pages/landing-page.content.yaml
+++ b/src/assets/content/pages/landing-page.content.yaml
@@ -6,7 +6,7 @@ carouselInfo:
   - title: Map the human body at single cell resolution
     body: Learn more about the thousands of experts building a Human Reference Atlas.
     image: assets/images/carousel1.svg
-    url: https://www.biorxiv.org/content/10.1101/2021.05.31.446440v2
+    url: https://doi.org/10.1038/s41556-021-00788-6
   - title: Contribute data to the Human Reference Atlas
     body: Register your data spatially using the Registration User Interface tool.
     image: assets/images/carousel2.svg


### PR DESCRIPTION
Carousel picture: Map the human body at single cell resolution  Get Started button:
Update the citation from https://www.biorxiv.org/content/10.1101/2021.05.31.446440v2 to the published paper: https://doi.org/10.1038/s41556-021-00788-6 
Börner, Katy, Sarah A. Teichmann, Ellen M. Quardokus, James C. Gee, Kristen Browne, David Osumi-Sutherland, Bruce W. Herr, et al. “Anatomical Structures, Cell Types and Biomarkers of the Human Reference Atlas.” Nature Cell Biology 23, no. 11 (November 1, 2021): 1117–28. https://doi.org/10.1038/s41556-021-00788-6.