### PR TITLE
Update registrationUserInterface.content.yaml

### DIFF
--- a/src/assets/content/pages/registrationUserInterface.content.yaml
+++ b/src/assets/content/pages/registrationUserInterface.content.yaml
@@ -22,11 +22,11 @@ interfacedata:
 acknowledgeData:
 - heading: Acknowledgments
   descriptions: |
-    The CCF and associated user interfaces are developed by the MC-IU team within the HuBMAP HIVE. The MC-IU team includes Katy Börner, Lisel Record, Bruce Herr II, Leonard Cross, Ellen Quardokus, and Andreas Bueckle, Indiana University, Bloomington, IN and Griffin Weber, Harvard Medical School, Boston, MA. Former members of the team are Paul Macklin, Randy Heiland, and Jim Sluka at Indiana University, Bloomington, IN and Samuel Friedman, Opto-Knowledge Systems, Inc. We acknowledge expert input from Jeffrey Spraggins, Sanjay Jain, and Clive Wasserfall and their teams as well as the overall HuBMAP consortium.
+    The CCF and associated user interfaces are developed by the MC-IU team within the HuBMAP HIVE. We acknowledge expert input from Jeffrey Spraggins, Sanjay Jain, and Clive Wasserfall and their teams as well as the overall HuBMAP consortium.
 
     The 3D reference organs were designed by Kristen Browne, U.S. National Library of Medicine using data from the <a href="https://www.nlm.nih.gov/research/visible/visible_human.html" target="">Visible Human Project</a>.
     
-    The work is funded by NIH Award <a href="https://reporter.nih.gov/project-details/9687220" target="">OT2OD026671</a>.
+    The work is funded by NIH Awards <a href="https://reporter.nih.gov/project-details/9687220" target="">OT2OD033756 and OT2OD026671</a>.
 
 useRuiButton:
   text: Use the Registration User Interface
@@ -34,7 +34,7 @@ useRuiButton:
 
 ruiSopData:
 - urls: ' SOP: Using the Registration User Interface'
-  href: https://docs.google.com/document/d/1PhVDMZDiH-SKAF7LrDhZfv3xjjlAhISmRWSQcfUF-9U/edit
+  href: https://doi.org/10.5281/zenodo.5575776
 
 title: Overview
 videoId: gY3_-LIoKaU


### PR DESCRIPTION
Replaced "superseded google doc link to SOP" with  correct link to Zenodo version of SOP Added additional funding award as per Lisel : OT2OD033756 and 

Removed exact "The MC-IU team consists of" because it's a moving target and we would be better off actually having a separate MC-IU team page that provides links to us?

Here's potential updated list, but what about : Is Paul Macklin  and Randy Heiland former or current?  Also what about Yashvardhan Jain? and the programmers?  Supriya Bidanta?

Updated list: 
The MC-IU team includes Katy Börner, Lisel Record, Bruce Herr II, Ellen Quardokus, Andreas Bueckle, Abraham Verdoes, Devin Wright, Daniel Bolin, Edward Lu, Katherine Gustilo, Libby Maier, Rachel Bajema, Heidi Schlehlein, Sarah Davis, Ushma Patel, and many students (Indiana University, Bloomington, IN),  David Osumi-Sutherland and Anita Caron (EMBL-European Bioinformatics Institute), David Van Valen (Caltech), Mark Musen and Josef Hardi (Stanford University)  Griffin Weber, Harvard Medical School, Boston, MA. Former members of the team are Paul Macklin, Randy Heiland, Leonard Cross and Jim Sluka at Indiana University, Bloomington, IN and Samuel Friedman, Opto-Knowledge Systems, Inc.