### PR TITLE
Update registrationUserInterface.content.yaml

### DIFF
--- a/src/assets/content/pages/registrationUserInterface.content.yaml
+++ b/src/assets/content/pages/registrationUserInterface.content.yaml
@@ -1,11 +1,11 @@
 headerCardDetails:
 - image: assets/images/rui.svg
-  title: CCF Registration User Interface (RUI)
+  title: Registration User Interface (RUI)
   subtitle: An interactive tool for registering tissue blocks spatially and annotating them semantically using ASCT+B Table terms
 
 overviewData:
 - heading: Overview
-  descriptions: This Registration User Interface (RUI) supports the registration of three-dimensional (3D) tissue blocks within 3D reference organs. A first beta of the CCF RUI became available in October 2020. The CCF RUI specification is available here, 3D reference organs are freely available on the CCF Portal, the ontology can be found on BioPortal, and the code is available on GitHub. The registration data is used in current versions of the Common Coordinate Framework (CCF, see CCF Portal for details) and the CCF Exploration User Interface (EUI) developed within HuBMAP.
+  descriptions: This Registration User Interface (RUI) supports the registration of three-dimensional (3D) tissue blocks within 3D reference organs. A first beta of the CCF RUI became available in October 2020. 3D reference organs are freely available on the HRA Portal in the <a href="https://humanatlas.io/3d-reference-library?version=1.3&organ=Allen%20Brain" target="">3D Reference Object Library</a>, the ontology can be found on <a href="https://bioportal.bioontology.org/ontologies/CCF" target="">BioPortal</a>, and the code is available on href="https://github.com/hubmapconsortium/ccf-ui" target="">GitHub</a>. The registration data is used in current versions of the Common Coordinate Framework and the on href=" https://hubmapconsortium.github.io/ccf-ui/” target="">Exploration User Interface (EUI) </a> developed within HuBMAP.
 
 interfacedata:
 - heading: How to use the Registration User Interface


### PR DESCRIPTION
Edited page to address Issue #40  Updates for RUI page #40  https://github.com/cns-iu/humanatlas.io/issues/40 -Remove CCF from title card title
-Update overview text to below:
This Registration User Interface (RUI) supports the registration of three-dimensional (3D) tissue blocks within 3D reference organs. A first beta of the CCF RUI became available in October 2020. 3D reference organs are freely available on the HRA Portal in the 3D Reference Object Library, the ontology can be found on BioPortal, and the code is available on GitHub. The registration data is used in current versions of the Common Coordinate Framework and the Exploration User Interface (EUI) developed within HuBMAP. Overview in text links - Labels and link routes:
3D Reference Object Library: https://humanatlas.io/3d-reference-library?version=1.3&organ=Allen%20Brain
BioPortal: https://bioportal.bioontology.org/ontologies/CCF
GitHub: https://github.com/hubmapconsortium/ccf-ui
Exploration User Interface (EUI): https://hubmapconsortium.github.io/ccf-ui/