### PR TITLE
corrected typo for longitude site wide

### DIFF
--- a/src/app/shared/simple-tile-items.ts
+++ b/src/app/shared/simple-tile-items.ts
@@ -2,7 +2,7 @@ import { TileItems } from './../components/simple-tile/tile-items';
 
 export const TileDefinition: TileItems[] = [
     {
-        title: 'A <b>Common Coordinate Framework (CCF)</b> for a human body provides a unique address for each cell in the human body. It is similar to the latitude-longtitude system used to navigate a world map.'
+        title: 'A <b>Common Coordinate Framework (CCF)</b> for a human body provides a unique address for each cell in the human body. It is similar to the latitude-longitude system used to navigate a world map.'
     },
     {
         title: 'A <b>Human Reference Atlas (HRA)</b> is a comprehensive, high-resolution, three-dimensional atlas of all the cells in the healthy human body. The Human Reference Atlas provides standard terminologies and data structures for describing specimens, biological structures, and spatial positions linked to existing ontologies.'


### PR DESCRIPTION
original misspelled: latitude-longtitude
corrected to : latitude-longitude system