### PR TITLE
updated Marc Halushka and Mike Synder descriptions

### DIFF
--- a/src/assets/content/pages/hra-editorial-board.content.yaml
+++ b/src/assets/content/pages/hra-editorial-board.content.yaml
@@ -25,7 +25,7 @@ boardMembersData:
     <a href="https://www.ge.com/research/people/fiona-ginty">Fiona Ginty</a>, Ph.D. leads a group of cellular and molecular scientists in Biosciences at GE Research who are inventing new methods and applications for the life sciences industry, including new cell therapy workflows, forensics, synthetic biology and cell imaging.
 - image: assets/images/marc_halushka.svg
   description: |
-    <a href="https://www.hopkinsmedicine.org/profiles/details/marc-halushka">Marc Halushka</a>, M.D., is a professor of pathology and oncology at the Johns Hopkins University School of Medicine. His areas of clinical expertise include cardiovascular pathology, autopsy pathology, and transplant pathology. He is a world-renowned expert on cardiovascular tissue microarrays.
+    <a href="https://www.hopkinsmedicine.org/profiles/details/marc-halushka">Marc Halushka</a>, M.D., is a professor of Pathology at the Johns Hopkins University School of Medicine. His areas of expertise include cardiovascular pathology, cell signal localization and microRNAs. He is a world-renowned expert on the use of cardiovascular tissue microarrays.
 - image: assets/images/matthias_kretzler.svg
   description: |
     <a href="https://medicine.umich.edu/dept/dcmb/matthias-kretzler-md">Matthias Kretzler</a>, M.D., Professor of Computational Medicine & Bioinformatics, Professor of Internal Medicine at University of Michigan. He performs research on systems biology of renal diseases, including nephrotic syndrome, diabetes, hypertension and autoimmune diseases of the kidney.
@@ -34,7 +34,7 @@ boardMembersData:
     <a href="https://obgyn.ucsd.edu/research/labs/laurent/index.html">Louise C. Laurent</a>, M.D., Ph.D. is the Vice Chair for Translational Research and Director of Perinatal Research for the UC San Diego Department of Obstetrics, Gynecology, & Reproductive Sciences and a member of the UC San Diego Embryonic Stem Cell Research Oversight Committee.
 - image: assets/images/mike_synder.svg
   description: |
-    <a href="https://med.stanford.edu/content/sm/snyderlab.html.html">Mike Snyder</a>, Ph.D., Stanford W. Ascherman, Professor in Genetics. He is a leader in the field of functional genomics and proteomics, and one of the major participants of the ENCODE project.
+    <a href="https://med.stanford.edu/content/sm/snyderlab.html.html">Mike Snyder</a>, Ph.D., Stanford W. Ascherman, Professor in Genetics. He is a leader in the field of multiomics profiling and big data, and one of the major participants of the HuBMAP, HTAN, MoTrPAC, Bridge2AI and ENCODE project.
 acknowledgmentsData:
   heading: Acknowledgments
   descriptions: We thank all members of the 17 consortia that participate in the Human Reference Atlas construction for their expert input and guidance.


### PR DESCRIPTION
update editorial board descriptions as per issue #34 Update Editorial Board profile text for Marc Halushka and Mike Snyder #34 https://github.com/cns-iu/humanatlas.io/issues/34 with text from google doc as per Libby: https://docs.google.com/document/d/1UDhbeN76o0BSaOgOdrSJzeZA3Z7RFi-BzA3DRx1ZGG0/edit#