### PR TITLE
correct paths for heart (again) and uterus ASCT+B

### DIFF
--- a/src/assets/table-data/release4.csv
+++ b/src/assets/table-data/release4.csv
@@ -5,7 +5,7 @@ Bone marrow,1,47,262,198,64,0,0,0,0,1,4,0,0,1,47,838,https://hubmapconsortium.gi
 Brain,183,127,256,256,0,0,0,0,61,64,0,138,0,183,127,346,https://hubmapconsortium.github.io/ccf-releases/v1.3/docs/asct-b/asct-b-allen-brain.html
 Eye,26,53,140,61,75,1,3,0,2,10,22,4,5,27,58,404,https://hubmapconsortium.github.io/ccf-releases/v1.3/docs/asct-b/asct-b-vh-eye.html
 Fallopian tube,72,18,26,13,13,0,0,0,63,15,18,33,1,84,81,27,https://hubmapconsortium.github.io/ccf-releases/v1.3/docs/asct-b/fallopian-tube.html
-Heart,52,28,44,44,0,0,0,0,23,2,1,0,7,64,230,76,https://hubmapconsortium.github.io/ccf-releases/v1.3/v1.3/docs/asct-b/asct-b/asct-b-vh-heart.html
+Heart,52,28,44,44,0,0,0,0,23,2,1,0,7,64,230,76,https://hubmapconsortium.github.io/ccf-releases/v1.3/docs/asct-b/asct-b-vh-heart.html
 Kidney,57,67,184,184,0,0,0,0,6,25,5,0,0,72,75,300,https://hubmapconsortium.github.io/ccf-releases/v1.3/docs/asct-b/kidney.html
 Knee,32,24,12,0,12,0,0,0,7,0,11,15,11,32,12,26,https://hubmapconsortium.github.io/ccf-releases/v1.3/docs/asct-b/knee.html
 Large intestine,54,58,166,83,83,0,0,0,0,1,3,0,0,287,1180,360,https://hubmapconsortium.github.io/ccf-releases/v1.3/docs/asct-b/asct-b-vh-large-intestine.html
@@ -24,4 +24,4 @@ Spleen,37,59,194,85,109,0,0,0,13,8,13,0,0,50,129,419,https://hubmapconsortium.gi
 Thymus,18,50,394,318,76,0,0,0,0,2,0,1,0,34,20,602,https://hubmapconsortium.github.io/ccf-releases/v1.3/docs/asct-b/asct-b-vh-thymus.html
 Ureter,7,14,30,30,0,0,0,0,1,0,11,1,0,7,14,61,https://hubmapconsortium.github.io/ccf-releases/v1.3/docs/asct-b/ureter.html
 Urinary bladder,16,15,30,30,0,0,0,0,0,0,11,5,0,16,16,63,https://hubmapconsortium.github.io/ccf-releases/v1.3/docs/asct-b/urinary-bladder.html
-Uterus,61,18,45,39,6,0,0,0,36,45,18,21,1,89,34,65,https://hubmapconsortium.github.io/ccf-releases/v1.3/v1.3/docs/asct-b/uterus.html
+Uterus,61,18,45,39,6,0,0,0,36,45,18,21,1,89,34,65,https://hubmapconsortium.github.io/ccf-releases/v1.3/docs/asct-b/uterus.html


### PR DESCRIPTION
there was an extra v1.3/ in both 
heart also had extra asct-b/
Corrected: 
https://hubmapconsortium.github.io/ccf-releases/v1.3/docs/asct-b/asct-b-vh-heart.html https://hubmapconsortium.github.io/ccf-releases/v1.3/docs/asct-b/uterus.html