### PR TITLE
added url to zenodo SOP; correct typos

### DIFF
--- a/src/assets/content/pages/hra-sop.content.yaml
+++ b/src/assets/content/pages/hra-sop.content.yaml
@@ -75,7 +75,7 @@ overviewData:
 
     > Mapping Experimental Data to the HRA Using OMAPs or Azimuth
 
-    > [ASCT+B Table](https://doi.org/10.5281/zenodo.5639622)[Communications](https://doi.org/10.5281/zenodo.5639622)
+    > [ASCT+B Table Communications](https://doi.org/10.5281/zenodo.5639622)
 
     [3D Reference Object Library](https://docs.google.com/document/d/1NOY6PsjGr1GDa39PZaTxoSvr0Ee4L8rW6lyYqNgyBC0/edit#heading=h.6ys5lo962o6b)
 
@@ -85,7 +85,7 @@ overviewData:
 
     > [3D Reference Object Approval](https://doi.org/10.5281/zenodo.5944196)
 
-    > Using 3D Reference Objects
+    > [Using 3D Reference Objects](https://doi.org/10.5281/zenodo.5639651)
 
     2D Functional Tissue Unit (FTU) Reference Object Library
 
@@ -100,8 +100,6 @@ overviewData:
     > Internal Validation of ASCT+B Tables, and 2D and 3D Reference Objects
 
     > External Review of ASCT+B Tables
-
-    > Validation Checks Performed by the DO-CMS
 
     > ASCT+B Table Validation with CCF Tools
 


### PR DESCRIPTION
ADD link to SOP: Using 3D Reference Objects
Investigated and corrected spacing issue in SOP:ASCT+B TableCommunications Removed > Validation Checks Performed by the DO-CMS since we do not have "DO-CMS" we can always revise to include other type of validation checks documentation