### PR TITLE
correct url citation link

### DIFF
--- a/src/app/pages/omaps/omaps.component.html
+++ b/src/app/pages/omaps/omaps.component.html
@@ -20,5 +20,4 @@
 </div>
 <ccf-choose-version [releaseDate]="omapsVersionData" [selectedDate]="placeholderDate" (selectedVersion)="setOmapsData($event)" class="description"></ccf-choose-version>
 <ccf-table [typeCount]="(tableData|async) ?? []" [displayedColumns]="(columns | async) ?? []" [columns]="columnHeaders" [isTotal]="true" class="description"></ccf-table>
-<ccf-page-data [data]="acknowledgementsData" class="description"></ccf-page-data>
 <ccf-page-data [data]="referencesData" class="description"></ccf-page-data>

--- a/src/app/pages/omaps/omaps.component.ts
+++ b/src/app/pages/omaps/omaps.component.ts
@@ -20,7 +20,6 @@ export class OmapsComponent {
   omapsHeading: PageHeaderItems[];
   overviewData: PageDataItems[];
   sopData: SopLinks[];
-  acknowledgementsData: PageDataItems[];
   omapsVersionData: ChooseVersion[];
   referencesData: PageDataItems[];
   displayedColumnsData = displayedColumnsData;
@@ -34,7 +33,6 @@ export class OmapsComponent {
     this.omapsHeading = data.omapsHeading;
     this.overviewData = data.overviewData;
     this.sopData = data.sopData;
-    this.acknowledgementsData = data.acknowledgementsData;
     this.omapsVersionData = data.omapsVersionData;
     this.referencesData = data.referencesData;
     this.placeholderDate = this.omapsVersionData[0];

--- a/src/assets/content/pages/omaps.content.yaml
+++ b/src/assets/content/pages/omaps.content.yaml
@@ -17,16 +17,11 @@ overviewData:
     To facilitate tissue mapping efforts within and beyond the HuBMAP community, OMAPs are designed for integration with the ASCT+B Reporter 
     (<a href="https://www.nature.com/articles/s41556-021-00788-6" target="">Börner et al. 2021</a>), a state-of-the-art visualization tool <a href="https://hubmapconsortium.github.io/ccf-asct-reporter" target="">https://hubmapconsortium.github.io/ccf-asct-reporter</a>.
     We strongly encourage inclusion of blood endothelial markers to empower construction of a human reference atlas using the vasculature common coordinate framework (VCCF), originally proposed by Dr. Zorina Galis 
-    (<a href="https://www.youtube.com/watch?v=ZGYU_dsb0j4&ab_channel=CyberinfrastructureforNetworkScienceCenter%28CNS%29" target="">Galis 2019</a>) and expanded upon here (
-    <a href="https://www.frontiersin.org/articles/10.3389/fcvm.2020.00029/full" target="">Weber, Ju, and Börner 2020</a>). We additionally recommend the inclusion of antibodies directed against one or more lymphatic endothelial markers to further our understanding of the “yet to be charted” human lymphatic system (<a href="http://biorxiv.org/content/early/2022/06/05/2022.06.03.494716.abstract">Radtke, Lukacs et al, 2022</a>), <a href="https://www.nhlbi.nih.gov/events/2021/yet-be-charted-mapping-lymphatic-system-across-body-scales-and-expertise-domains">NHLBI, NIH 2021</a>), <a href="https://www.niddk.nih.gov/news/meetings-workshops/2022/yet-to-be-charted-lymphatic-system-in-health-and-disease">National Heart, Lung, and Blood Institute (NHLBI), and National Institute of Diabetes and Digestive and Kidney Diseases (NIDDK), 2022</a>).
+    (<a href="https://www.youtube.com/watch?v=ZGYU_dsb0j4&ab_channel=CyberinfrastructureforNetworkScienceCenter%28CNS%29" target="">Galis 2019</a>) and expanded upon here (<a href="https://www.frontiersin.org/articles/10.3389/fcvm.2020.00029/full" target="">Weber, Ju, and Börner 2020</a>). We additionally recommend the inclusion of antibodies directed against one or more lymphatic endothelial markers to further our understanding of the “yet to be charted” human lymphatic system (<a href="https://www.nature.com/articles/s41591-022-01865-5">Radtke, Lukacs et al, 2022</a>), <a href="https://www.nhlbi.nih.gov/events/2021/yet-be-charted-mapping-lymphatic-system-across-body-scales-and-expertise-domains">NHLBI, NIH 2021</a>), <a href="https://www.niddk.nih.gov/news/meetings-workshops/2022/yet-to-be-charted-lymphatic-system-in-health-and-disease">National Heart, Lung, and Blood Institute (NHLBI), and National Institute of Diabetes and Digestive and Kidney Diseases (NIDDK), 2022</a>).
 
 sopData:
 - urls: 'SOP: Construction of Organ Mapping Antibody Panels for Multiplexed Antibody-Based Imaging of Human Tissues'
   href: https://doi.org/10.5281/zenodo.5749882
-
-acknowledgementsData:
-- heading: Acknowledgements
-  descriptions: We are grateful for engaging and thoughtful discussions from the Affinity Reagent Imaging and Validation and ASCT+B working groups, HuBMAP Consortium. This work was supported, in part, by the Intramural Research Program of the NIH, National Institute of Allergy and Infectious Disease and National Cancer Institute. This work was also supported by NIH Awards UH3 CA246635 and 1OT2OD026671.
 
 referencesData:
 - heading: References


### PR DESCRIPTION
As per Andrea Radtke : use https://www.nature.com/articles/s41591-022-01865-5 instead of bioxiv paper which was wrong citation Remove extra space between Weber and (
Remove acknowledgments as per Lisel; she discussed with Andrea Radtke on January 9th, OK to go with single About MC-IU acknowledgement.