### PR TITLE
added sop link

### DIFF
--- a/src/app/pages/hra-sop/hra-sop.component.html
+++ b/src/app/pages/hra-sop/hra-sop.component.html
@@ -1,4 +1,4 @@
 <ccf-page-header [headerCard]="pageHeader"></ccf-page-header>
 <announcement-card class="description"></announcement-card>
-<ccf-page-data [data]="overviewData"></ccf-page-data>
-<ccf-page-data [data]="acknowledgmentsData"></ccf-page-data>
+<ccf-page-data [data]="overviewData" class="description"></ccf-page-data>
+<ccf-page-data [data]="acknowledgmentsData" class="description"></ccf-page-data>

--- a/src/assets/content/pages/hra-editorial-board.content.yaml
+++ b/src/assets/content/pages/hra-editorial-board.content.yaml
@@ -6,7 +6,7 @@ overviewData:
   heading: | 
     Overview
   descriptions: |
-    The HRA editorial is composed of interdisciplinary experts from pathology, surgery, and single cell experimentalists.
+    The HRA editorial board is composed of interdisciplinary experts from pathology, surgery, and single cell experimentalists.
 
     The board will meet virtually every six months—in Nov and May of each year—to
 

--- a/src/assets/content/pages/hra-sop.content.yaml
+++ b/src/assets/content/pages/hra-sop.content.yaml
@@ -4,7 +4,7 @@ pageHeader:
   subtitle: Standard operating procedures for Human Reference Atlas construction, visualization, and usage
 
 overviewData:
-  heading: Overview
+  heading: Table of Contents
   descriptions: |
     [Overview](https://docs.google.com/document/u/0/d/1oMPWB454auN-FTe7XVtxWk7SbJgWFtcS6LvOjgN89wA/edit)
 
@@ -105,7 +105,7 @@ overviewData:
 
     > ASCT+B Reporter Validation Checks
 
-    > HRA Editorial Process
+    > <a href="https://zenodo.org/record/7577521#.Y9R0knbMJmM" target="_blank">HRA Editorial Board Procedures</a>
 
     [Human Reference Atlas Tracking and Publication](https://docs.google.com/document/d/1ZlJV61GA60ZtWoCu8HE93fBPOxPootfAe-ggAzipWEM/edit#heading=h.6ys5lo962o6b)
 


### PR DESCRIPTION
- Updated HRA Editorial Process to HRA Editorial Board Procedures and added SOP link to it. #76
- Renamed Overview to Table of Contents
- Fixed the spacing between the sections and at the end of the page
- Fixed typo in #78. Changed HRA Editorial to HRA Editorial Board