### PR TITLE
updated about page route and card

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -123,7 +123,7 @@ const routes: Routes = [
     resolve: { content: ContentResolver },
   },
   {
-    path: 'about-mc-iu',
+    path: 'team',
     component: AboutComponent,
     data: { contentFile: 'about.content' },
     resolve: { content: ContentResolver },

--- a/src/app/pages/about/about.component.ts
+++ b/src/app/pages/about/about.component.ts
@@ -14,7 +14,7 @@ interface About {
 }
 
 @Component({
-  selector: 'about-mc-iu',
+  selector: 'team',
   templateUrl: './about.component.html',
   styleUrls: ['./about.component.scss']
 })

--- a/src/app/shared/navigation-items.ts
+++ b/src/app/shared/navigation-items.ts
@@ -147,8 +147,8 @@ export const NAVIGATION_ITEMS: NavItems[] = [
     menuName: 'About',
     children: [
       {
-        menuName: 'About MC-IU',
-        route: 'about-mc-iu'
+        menuName: 'About the Team',
+        route: 'team'
       },
       {
         menuName: 'HRA Editorial Board',

--- a/src/assets/content/pages/about.content.yaml
+++ b/src/assets/content/pages/about.content.yaml
@@ -1,5 +1,5 @@
 pageHeaderData:
-- title: About MC-IU
+- title: About the Team
   subtitle: Learn about the HuBMAP Infrastructure, Visualization, & Engagement (HIVE) Mapping Component Indiana University (MC-IU) Team
   image: assets/images/about.svg
 


### PR DESCRIPTION
- Updated the route for the about page to 'team'.
- Updated Menu name and Card name to 'About the Team'