### PR TITLE
removed HRA from titles

### DIFF
--- a/src/app/shared/navigation-items.ts
+++ b/src/app/shared/navigation-items.ts
@@ -83,16 +83,16 @@ export const NAVIGATION_ITEMS: NavItems[] = [
         disabled: true
       },
       {
-        menuName: 'HRA Organ VR Gallery',
+        menuName: 'Organ Gallery in VR',
         route: 'hra-organ-gallery-in-vr'
       },
       {
-        menuName: 'HRA Millitome',
+        menuName: 'Millitome',
         route: 'hra-millitome',
         disabled: true
       },
       {
-        menuName: 'Application Programming Interfaces',
+        menuName: 'Application Programming Interfaces (APIs)',
         route: 'api',
         disabled: true
       },

--- a/src/assets/content/pages/hra-api.content.yaml
+++ b/src/assets/content/pages/hra-api.content.yaml
@@ -1,6 +1,6 @@
 - type: header
   headerCard:
-  - title: Human Reference Atlas Application Programming Interfaces
+  - title: Application Programming Interfaces (API)
     subtitle: Query and interact with the HRA using Python, JavaScript, SPARQL, REST,
       and more
     image: assets/images/hra_api.svg

--- a/src/assets/content/pages/hra-millitome.content.yaml
+++ b/src/assets/content/pages/hra-millitome.content.yaml
@@ -1,6 +1,6 @@
 - type: header
   headerCard:
-  - title: Human Reference Atlas Millitome
+  - title: Millitome
     subtitle: A unique 3D printed tool for the uniform sectioning of organs
     image: assets/images/hra_milletome.svg
 

--- a/src/assets/content/pages/overview-tools.content.yaml
+++ b/src/assets/content/pages/overview-tools.content.yaml
@@ -19,31 +19,31 @@
 - type: longCard
   longButtonItems:
   - icon: assets/images/asctb_reporter.svg
-    title: CCF Anatomical Structures, Cell Types, and Biomarkers (ASCT+B) Reporter
+    title: Anatomical Structures, Cell Types, and Biomarkers (ASCT+B) Reporter
     body: A visualization tool for human organ experts to explore and compare ASCT+B Tables
     route: asctb-reporter
   - icon: assets/images/cell_graphs.svg
-    title: CCF Cell Population Graphs
+    title: Cell Population Graphs
     body: An interactive tool for exploring and comparing cell populations
     route: cell-population-graphs
   - icon: assets/images/rui.svg
-    title: CCF Registration User Interface (RUI)
+    title: Registration User Interface (RUI)
     body: An interactive tool for registering tissue blocks spatially and annotating them semantically using ASCT+B table terms
     route: registration-user-interface
   - icon: assets/images/eui.svg
-    title: CCF Exploration User Interface (EUI)
+    title: Exploration User Interface (EUI)
     body: An interactive tool for exploring and validating spatially registered tissue blocks and cell type populations
     route: exploration-user-interface
   - icon: assets/images/vr_gallery.svg
-    title: HRA Organ VR Gallery
+    title: Organ Gallery in VR
     body: An immersive application that allows users to explore 3D reference organs, anatomical structures, and cell types in virtual reality
     route: hra-organ-gallery-in-vr
   - icon: assets/images/hra_milletome.svg
-    title: Human Reference Atlas Millitome
+    title: Millitome
     body: A unique 3D printed tool and standard operating procedure for the uniform sectioning of organs
     route: hra-millitome
   - icon: assets/images/hra_api.svg
-    title: Human Reference Atlas Application Programming Interfaces
+    title: Application Programming Interfaces (APIs)
     body: Query and interact with the HRA using Python, JavaScript, SPARQL, REST, and more
     route: api
   # - icon: assets/images/hra_usage.svg


### PR DESCRIPTION
Tools Overview page: Remove CCF from all button cards
 Tools Overview page: Remove HRA or Human Reference Atlas from button cards
 Tools Overview page: Update HRA Organ VR gallery to Organ Gallery in VR
 Tools Overview page: Add (APIs) at the end of the APIs button card.
 Tools navigation menu: Update HRA Organ VR gallery to Organ Gallery in VR
 Tools navigation menu: Update HRA Millitome to Millitome
 Tools navigation menu: Update Application Programming Interfaces to Application Programming Interfaces (APIs)
 [API page](https://humanatlas.io/api): Update the title card's title from Human Reference Atlas Application Programming Interfaces to Application Programming Interfaces (API)
 [Millitome page](https://humanatlas.io/hra-millitome): Update the title card's title from Human Reference Atlas Millitome to Millitome
 
 Performed all the above changes